### PR TITLE
Align version catalog aliases with a shared convention

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -25,12 +25,12 @@ kotlin {
          * Only link against pods the library (lorem-ipsum and google-maps) depends on.
          */
         pod("LoremIpsum") {
-            version = libs.versions.cocoapods.loremIpsum.get()
+            version = libs.versions.cocoapods.lorem.ipsum.get()
             linkOnly = true
         }
 
         pod("GoogleMaps") {
-            version = libs.versions.cocoapods.googleMaps.get()
+            version = libs.versions.cocoapods.google.maps.get()
             linkOnly = true
         }
 

--- a/google-maps/build.gradle.kts
+++ b/google-maps/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         noPodspec()
 
         pod("GoogleMaps") {
-            version = libs.versions.cocoapods.googleMaps.get()
+            version = libs.versions.cocoapods.google.maps.get()
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
+cocoapods-google-maps = "10.3.0"
+cocoapods-lorem-ipsum = "2.0.0"
 compose-multiplatform = "1.10.3"
 kotlin = "2.3.20"
-cocoapods-LoremIpsum = "2.0.0"
-cocoapods-GoogleMaps = "10.3.0"
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/lorem-ipsum/build.gradle.kts
+++ b/lorem-ipsum/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         noPodspec()
 
         pod("LoremIpsum") {
-            version = libs.versions.cocoapods.loremIpsum.get()
+            version = libs.versions.cocoapods.lorem.ipsum.get()
         }
     }
 


### PR DESCRIPTION
Renames the version catalog aliases so that each dependency has one canonical name shared across the Kotlin Multiplatform samples, and sorts the `[versions]` block alphabetically. `androidx-*` covers `androidx.*` together with its `org.jetbrains.androidx.*` multiplatform ports, which share one alias per library, while `compose-*` is Compose Multiplatform itself; separate release trains stay separate, so `androidx-navigation` (2.x) and `androidx-navigation3` (1.x) are distinct aliases. No resolved dependency version changes: every rename keeps its value, and any aliases merged together already held identical versions. The `libs.versions.*` accessors in the build scripts are updated to match the renamed `cocoapods-*` aliases; the pod names themselves are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
