### PR TITLE
Align version catalog aliases with a shared convention

### DIFF
--- a/google-maps/build.gradle.kts
+++ b/google-maps/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
         swiftPackage(
             url = url("https://github.com/googlemaps/ios-maps-sdk.git"),
-            version = exact(libs.versions.spm.googleMaps.get()),
+            version = exact(libs.versions.spm.google.maps.get()),
             products = listOf(product("GoogleMaps")),
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
+compose-material3 = "1.10.0-alpha05"
 compose-multiplatform = "1.10.3"
-material3 = "1.10.0-alpha05"
 kotlin = "2.4.0-Beta2"
-spm-LoremIpsum = "2.0.1"
-spm-GoogleMaps = "10.6.0"
+spm-google-maps = "10.6.0"
+spm-lorem-ipsum = "2.0.1"
 
 [libraries]
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
@@ -13,7 +13,7 @@ compose-resources = { module = "org.jetbrains.compose.components:components-reso
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-multiplatform" }
 compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-multiplatform" }
-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/lorem-ipsum/build.gradle.kts
+++ b/lorem-ipsum/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
         swiftPackage(
             url = url("https://github.com/lukaskubanek/LoremIpsum.git"),
-            version = from(libs.versions.spm.loremIpsum.get()),
+            version = from(libs.versions.spm.lorem.ipsum.get()),
             products = listOf(product("LoremIpsum")),
         )
     }


### PR DESCRIPTION
Renames the version catalog aliases on this branch so that each dependency has one canonical name, matching what the default branch now uses. `androidx-*` covers `androidx.*` together with its `org.jetbrains.androidx.*` multiplatform ports, `compose-*` is Compose Multiplatform itself, and the `[versions]` block is sorted alphabetically. No resolved dependency version changes: every rename keeps its value, and any aliases merged together already held identical versions.
 The two `libs.versions.spm.*` accessors in the build scripts are updated to match the renamed aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
