### PR TITLE
Add basic GitHub Actions CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build-ios:
+    name: Build iOS simulator app
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
+
+      - name: Generate dummy framework
+        run: ./gradlew :composeApp:generateDummyFramework
+
+      - name: Install CocoaPods dependencies
+        run: cd iosApp && pod install
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild build \
+          -workspace iosApp/iosApp.xcworkspace \
+          -configuration Debug \
+          -scheme iosApp \
+          -sdk iphonesimulator \
+          -arch arm64 \
+          -derivedDataPath ./build \
+          CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
Adds a workflow building the iOS app in debug, which is the only platform this sample targets.

Because the Kotlin module is consumed as a local pod, the job runs three steps in order:

1. `:composeApp:generateDummyFramework` — the podspec refuses to load until the framework directory exists
2. `pod install` — generates the workspace
3. `xcodebuild` against `iosApp.xcworkspace` for the simulator

Verified locally on macOS; all three pass.