### PR TITLE
Add basic GitHub Actions CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches: [ spm_import ]
+  pull_request:
+    branches: [ spm_import ]
+  workflow_dispatch:
+
+jobs:
+  build-ios:
+    name: Build iOS simulator app
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild build \
+          -project iosApp/iosApp.xcodeproj \
+          -configuration Debug \
+          -scheme iosApp \
+          -sdk iphonesimulator \
+          -arch arm64 \
+          -derivedDataPath ./build \
+          CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
Adds a workflow building the iOS app in debug, targeting the `spm_import` branch. iOS is the only platform this sample targets.

The Xcode project builds the Kotlin framework through its Gradle build phase, so the single `xcodebuild` step covers the Kotlin side as well as the Swift one.

Verified locally on macOS; passes.