### PR TITLE
Add basic GitHub Actions CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches: [ local_spm_migration ]
+  pull_request:
+    branches: [ local_spm_migration ]
+  workflow_dispatch:
+
+jobs:
+  build-ios:
+    name: Build iOS simulator app
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5.0.0
+
+      - name: Integrate SwiftPM linkage package
+        run: XCODEPROJ_PATH="$PWD/iosApp/iosApp.xcodeproj" ./gradlew :composeApp:integrateLinkagePackage
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild build \
+          -project iosApp/iosApp.xcodeproj \
+          -configuration Debug \
+          -scheme iosApp \
+          -sdk iphonesimulator \
+          -arch arm64 \
+          -derivedDataPath ./build \
+          CODE_SIGNING_ALLOWED=NO

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 compose-multiplatform = "1.10.3"
-kotlin = "2.3.20-titan-224"
+kotlin = "2.4.10"
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
Adds a workflow building the iOS app in debug, targeting the `local_spm_migration` branch. iOS is the only platform this sample targets.

The job integrates the SwiftPM linkage package before building:

```
XCODEPROJ_PATH="$PWD/iosApp/iosApp.xcodeproj" ./gradlew :composeApp:integrateLinkagePackage
```

Without it the build stops with *"You have SwiftPM dependencies with embedAndSign integration"*, since the synthetic linkage package has to be regenerated whenever the Kotlin version moves. `XCODEPROJ_PATH` has to be absolute — with a relative path Gradle writes the package to the wrong directory and `xcodebuild` then fails on a package that does not exist.

### Also bumps Kotlin

This branch carries a second commit moving the sample off `2.3.20-titan-224` to **2.4.10**. That was a JetBrains dev build pinned during the CocoaPods-to-SwiftPM migration, and it no longer resolves from any repository the sample declares, so nothing here could build until it moved to a released version.

Verified locally on macOS: the project configures, and the linkage and `xcodebuild` steps both pass.